### PR TITLE
[#12] URL 클래스 getter 구현

### DIFF
--- a/src/url.cpp
+++ b/src/url.cpp
@@ -333,3 +333,21 @@ int Url::ParseUriComponent(std::string& request_uri) {
 
   return OK;
 }
+
+const std::string& Url::getScheme() const { return this->scheme_; }
+
+const std::string& Url::getUser() const { return this->user_; }
+
+const std::string& Url::getPassword() const { return this->password_; }
+
+const std::string& Url::getHost() const { return this->host_; }
+
+int Url::getPort() const { return this->port_; }
+
+const std::list<Url::PathSegment>& Url::getPathSegments() const {
+  return this->path_segments_;
+}
+
+const std::map<const std::string, std::string>& Url::getQuery() const {
+  return this->query_;
+}

--- a/src/url.hpp
+++ b/src/url.hpp
@@ -50,6 +50,14 @@ class Url {
   ~Url();
 
   int ParseUriComponent(std::string& request_uri);
+
+  const std::string& getScheme() const;
+  const std::string& getUser() const;
+  const std::string& getPassword() const;
+  const std::string& getHost() const;
+  int getPort() const;
+  const std::list<PathSegment>& getPathSegments() const;
+  const std::map<const std::string, std::string>& getQuery() const;
 };
 
 #endif


### PR DESCRIPTION
Url 클래스 멤버 변수에 대한 getter를 개방한다.

Fixes: #12