### PR TITLE
[#9] Request Message 파싱 알고리즘 구현

### DIFF
--- a/src/abnf.cpp
+++ b/src/abnf.cpp
@@ -18,7 +18,7 @@ bool Abnf::IsVchar(char c) {
   }
 }
 
-bool Abnf::IsObsText(char c) {
+bool Abnf::IsObsText(unsigned char c) {
   // obs-text = %x80-FF
   if (c < 128 || c > 255) {
     return false;

--- a/src/abnf.cpp
+++ b/src/abnf.cpp
@@ -31,7 +31,6 @@ bool Abnf::IsToken(const std::string& s) {
   // token = 1*tchar
   for (size_t i = 0; i < s.length(); ++i) {
     char c = s[i];
-
     /*
                         tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*"
                                 / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
@@ -54,10 +53,10 @@ bool Abnf::IsToken(const std::string& s) {
       case '`':
       case '|':
       case '~':
-        return true;
+        break;
       default:
         if (std::isalnum(c)) {
-          return true;
+          break;
         } else {
           return false;
         }

--- a/src/abnf.cpp
+++ b/src/abnf.cpp
@@ -1,5 +1,32 @@
 #include "abnf.hpp"
 
+bool Abnf::IsWhiteSpace(char c) {
+  // WS = SP / HTAB
+  if (c == 9 || c == 32) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+bool Abnf::IsVchar(char c) {
+  // VCHAR =  %x21-7E
+  if (c < 33 || c > 126) {
+    return false;
+  } else {
+    return true;
+  }
+}
+
+bool Abnf::IsObsText(char c) {
+  // obs-text = %x80-FF
+  if (c < 128 || c > 255) {
+    return false;
+  } else {
+    return true;
+  }
+}
+
 bool Abnf::IsToken(const std::string& s) {
   // token = 1*tchar
   for (size_t i = 0; i < s.length(); ++i) {

--- a/src/abnf.cpp
+++ b/src/abnf.cpp
@@ -1,5 +1,44 @@
 #include "abnf.hpp"
 
+bool Abnf::IsToken(const std::string& s) {
+  // token = 1*tchar
+  for (size_t i = 0; i < s.length(); ++i) {
+    char c = s[i];
+
+    /*
+                        tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*"
+                                / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
+                                / DIGIT / ALPHA
+                                ; any VCHAR, except delimiters
+    */
+    switch (c) {
+      case '!':
+      case '#':
+      case '$':
+      case '%':
+      case '&':
+      case '\'':
+      case '*':
+      case '+':
+      case '-':
+      case '.':
+      case '^':
+      case '_':
+      case '`':
+      case '|':
+      case '~':
+        return true;
+      default:
+        if (std::isalnum(c)) {
+          return true;
+        } else {
+          return false;
+        }
+    }
+  }
+  return true;
+}
+
 bool Abnf::IsUnreserved(char c) {
   // unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
   if (std::isalnum(c)) {

--- a/src/abnf.cpp
+++ b/src/abnf.cpp
@@ -1,5 +1,7 @@
 #include "abnf.hpp"
 
+bool Abnf::IsOctet(char c) { return (static_cast<unsigned char>(c) <= 255); }
+
 bool Abnf::IsHost(std::string& s) {
   // host = IP-literal / IPv4address / reg-name
   size_t delimiter_pos;

--- a/src/abnf.cpp
+++ b/src/abnf.cpp
@@ -1,5 +1,71 @@
 #include "abnf.hpp"
 
+bool Abnf::IsHost(std::string& s) {
+  // host = IP-literal / IPv4address / reg-name
+  size_t delimiter_pos;
+  std::string sub_component;
+  char* end_ptr;
+
+  size_t length = s.length();
+  if (length == 0) {
+    /*
+        A recipient that processes "http" URI with an empty host identifier
+                reference MUST reject it as invalid.
+        Section 4.2.1 of [HTTP]
+    */
+    return false;
+  } else if (s[0] == '[') {
+    // IP-literal = "[" ( IPv6address / IPvFuture ) "]"
+    // 네트워크 정책 상 IPv6를 지원하지 않는다.
+    return false;
+  } else {
+    // IPv4address = dec-octet "." dec-octet "." dec-octet "." dec-octet
+    /*
+            dec-octet = DIGIT               ; 0-9
+                        / %x31-39 DIGIT     ; 10-99
+                        / "1" 2DIGIT        ; 100-199
+                        / "2" %x30-34 DIGIT ; 200-249
+                        / "25" %x30-35      ; 250-255
+    */
+
+    bool is_ip_v4_address = true;
+    size_t pre_delimiter_pos = 0;
+    for (int i = 0; i < 4; ++i) {
+      delimiter_pos = s.find(".", pre_delimiter_pos);
+      sub_component = s.substr(pre_delimiter_pos, delimiter_pos);
+      pre_delimiter_pos = delimiter_pos;
+      long dec_octet = strtol(sub_component.c_str(), &end_ptr, 10);
+      if (end_ptr == sub_component || *end_ptr != 0 || dec_octet < 0 ||
+          dec_octet > 255) {
+        is_ip_v4_address = false;
+        break;
+      }
+    }
+
+    if (is_ip_v4_address == false) {
+      // reg-name = *( unreserved / pct-encoded / sub-delims )
+      for (size_t i = 0; i < length; ++i) {
+        char c = s[i];
+
+        switch (c) {
+          c = Abnf::DecodePctEncoded(s, i);
+          length = s.length();
+          if (c < 0) {
+            return false;
+          }
+          default:
+            if (!Abnf::IsUnreserved(c) && !Abnf::IsSubDlims(c)) {
+              return false;
+            }
+            break;
+        }
+      }
+    }
+
+    return true;
+  }
+}
+
 bool Abnf::IsWhiteSpace(char c) {
   // WS = SP / HTAB
   if (c == 9 || c == 32) {
@@ -33,9 +99,8 @@ bool Abnf::IsToken(const std::string& s) {
     char c = s[i];
     /*
                         tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*"
-                                / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
-                                / DIGIT / ALPHA
-                                ; any VCHAR, except delimiters
+                                / "+" / "-" / "." / "^" / "_" / "`" / "|" /
+       "~" / DIGIT / ALPHA ; any VCHAR, except delimiters
     */
     switch (c) {
       case '!':

--- a/src/abnf.hpp
+++ b/src/abnf.hpp
@@ -7,6 +7,7 @@
 class Abnf {
  private:
  public:
+  static bool IsHost(std::string& s);
   static bool IsWhiteSpace(char c);
   static bool IsVchar(char c);
   static bool IsObsText(unsigned char c);

--- a/src/abnf.hpp
+++ b/src/abnf.hpp
@@ -7,6 +7,9 @@
 class Abnf {
  private:
  public:
+  static bool IsWhiteSpace(char c);
+  static bool IsVchar(char c);
+  static bool IsObsText(char c);
   static bool IsToken(const std::string& s);
   static bool IsUnreserved(const char c);
   static bool IsSubDlims(const char c);

--- a/src/abnf.hpp
+++ b/src/abnf.hpp
@@ -7,6 +7,7 @@
 class Abnf {
  private:
  public:
+  static bool IsOctet(char c);
   static bool IsHost(std::string& s);
   static bool IsWhiteSpace(char c);
   static bool IsVchar(char c);

--- a/src/abnf.hpp
+++ b/src/abnf.hpp
@@ -9,7 +9,7 @@ class Abnf {
  public:
   static bool IsWhiteSpace(char c);
   static bool IsVchar(char c);
-  static bool IsObsText(char c);
+  static bool IsObsText(unsigned char c);
   static bool IsToken(const std::string& s);
   static bool IsUnreserved(const char c);
   static bool IsSubDlims(const char c);

--- a/src/abnf.hpp
+++ b/src/abnf.hpp
@@ -7,6 +7,7 @@
 class Abnf {
  private:
  public:
+  static bool IsToken(const std::string& s);
   static bool IsUnreserved(const char c);
   static bool IsSubDlims(const char c);
   static char DecodePctEncoded(std::string& s, const size_t pos);

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -56,7 +56,20 @@ int Request::ParseRequestLine(std::string& request_line) {
   return OK;
 }
 
-int Request::ParseHttpHeader(std::string& header) {
+int Request::ParseCombinedFieldValue(std::string& field_name,
+                                     std::string& combined_field_value) {
+  if (field_name == "host") {
+    return ERROR;
+  } else if (field_name == "content-length") {
+    return ERROR;
+  } else if (field_name == "transfer-encoding") {
+    return ERROR;
+  }
+  this->headers_[field_name] = combined_field_value;
+  return OK;
+}
+
+int Request::ParseFieldValue(std::string& field_line) {
   /*
                 field-line = field-name ":" OWS field-value OWS
                 field-name = token
@@ -70,17 +83,18 @@ int Request::ParseHttpHeader(std::string& header) {
   */
   std::string field_name;
   std::string field_value;
-  size_t delimiter_pos = header.find(':');
+  size_t delimiter_pos = field_line.find(':');
   if (delimiter_pos == std::string::npos) {
     return ERROR;
   }
 
-  field_name = header.substr(0, delimiter_pos);
+  field_name = field_line.substr(0, delimiter_pos);
+  ToCaseInsensitve(field_name);
   if (field_name.length() == 0 || !Abnf::IsToken(field_name)) {
     return ERROR;
   }
 
-  field_value = Trim(header.substr(delimiter_pos + 1));
+  field_value = Trim(field_line.substr(delimiter_pos + 1));
   for (size_t i = 0; i < field_value.length(); i++) {
     unsigned char c = field_value[i];
     if (Abnf::IsVchar(c) || Abnf::IsObsText(c) || Abnf::IsWhiteSpace(c)) {
@@ -89,7 +103,81 @@ int Request::ParseHttpHeader(std::string& header) {
       return ERROR;
     }
   }
-  this->headers_.insert(std::make_pair(field_name, field_value));
+
+  HeadersIterator field_iter = this->headers_.find(field_name);
+  if (field_iter != this->headers_.end()) {
+    std::string combined_field_value = field_iter->second + ", " + field_value;
+    if (ParseCombinedFieldValue(field_name, combined_field_value) == ERROR) {
+      return ERROR;
+    }
+  } else {
+    this->headers_.insert(std::make_pair(field_name, field_value));
+  }
+  return OK;
+}
+
+int Request::ParseStandardHeader() {
+  HeadersIterator end = this->headers_.end();
+  std::string field_value;
+  char* end_ptr;
+
+  HeadersIterator it = this->headers_.find("host");
+  if (it == end) {
+    return ERROR;
+  } else {
+    field_value = it->second;
+    this->http_host_ = field_value;
+
+    size_t delimiter_pos;
+    std::string sub_component;
+
+    delimiter_pos = field_value.find(':');
+    if (delimiter_pos != std::string::npos) {
+      // port = *DIGIT
+      sub_component = field_value.substr(delimiter_pos + 1);
+      long port = strtol(sub_component.c_str(), &end_ptr, 10);
+      if (end_ptr == sub_component || *end_ptr != 0 || port < 0 ||
+          port > 65535) {
+        return ERROR;
+      }
+
+      field_value = field_value.substr(0, delimiter_pos);
+    }
+
+    if (!Abnf::IsHost(field_value)) {
+      return ERROR;
+    }
+  }
+
+  it = this->headers_.find("transfer-encoding");
+  if (it != end) {
+    field_value = it->second;
+    std::vector<std::string> buffer = Split(field_value, ',');
+
+    std::vector<std::string>::iterator buffer_it = buffer.begin();
+    std::vector<std::string>::iterator buffer_end = buffer.end();
+
+    std::string token;
+    for (; buffer_it < buffer_end; ++buffer_it) {
+      token = Trim(*buffer_it);
+      token = token.substr(0, token.find(';'));
+      ToCaseInsensitve(token);
+      this->http_transfer_encoding_.push_back(token);
+    }
+  }
+
+  it = this->headers_.find("content-length");
+  if (it != end) {
+    if (this->headers_.find("transfer-encoding") != end) {
+      return ERROR;
+    }
+    field_value = it->second;
+    long content_length = strtol(field_value.c_str(), &end_ptr, 10);
+    if (end_ptr == field_value || *end_ptr != 0) {
+      return ERROR;
+    }
+    this->http_content_length_ = content_length;
+  }
   return OK;
 }
 
@@ -124,27 +212,34 @@ int Request::ReceiveRequest(char* buff, ssize_t size) {
       } else {
         if (line.empty()) {
           break;
-        } else if (this->ParseHttpHeader(line) == ERROR) {
+        } else if (this->ParseFieldValue(line) == ERROR) {
           return ERROR;
         }
       }
     }
   }
+  if (ParseStandardHeader() == ERROR) {
+    return ERROR;
+  }
 
   return OK;
 }
 
-const std::string& Request::getMethod() const { return this->method_; }
+const std::string& Request::get_method() const { return this->method_; }
 
-const Url& Request::getUrl() const { return this->url_; }
+const Url& Request::get_url() const { return this->url_; }
 
-int Request::getMajorVersion() const { return this->major_version_; }
+int Request::get_major_version() const { return this->major_version_; }
 
-int Request::getMinorVersion() const { return this->minor_version_; }
+int Request::get_minor_version() const { return this->minor_version_; }
 
-const std::multimap<const std::string, std::string>& Request::getHeaders()
-    const {
+const std::map<const std::string, std::string>& Request::get_headers() const {
   return this->headers_;
 }
 
-const std::string& Request::getBody() const { return this->body_; }
+const std::vector<std::string> Request::get_http_transfer_encoding() const {
+  return this->http_transfer_encoding_;
+}
+
+int Request::get_http_content_length() const { return this->http_content_length_; }
+const std::string& Request::get_body() const { return this->body_; }

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -133,3 +133,18 @@ int Request::ReceiveRequest(char* buff, ssize_t size) {
 
   return OK;
 }
+
+const std::string& Request::getMethod() const { return this->method_; }
+
+const Url& Request::getUrl() const { return this->url_; }
+
+int Request::getMajorVersion() const { return this->major_version_; }
+
+int Request::getMinorVersion() const { return this->minor_version_; }
+
+const std::multimap<const std::string, std::string>& Request::getHeaders()
+    const {
+  return this->headers_;
+}
+
+const std::string& Request::getBody() const { return this->body_; }

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -1,0 +1,63 @@
+#include "request.hpp"
+
+Request::Request() : url_(Url()) {}
+Request::Request(const Request& obj) { *this = obj; }
+Request::~Request() {}
+Request& Request::operator=(const Request& obj) {
+  if (this != &obj) {
+    this->method_ = obj.method_;
+    this->url_ = obj.url_;
+    this->major_version_ = obj.major_version_;
+    this->minor_version_ = obj.minor_version_;
+    this->headers_ = obj.headers_;
+    this->body_ = obj.body_;
+  }
+  return *this;
+}
+
+int Request::ParseMethod(std::string& method) {
+  // method = token = 1*tchar
+  if (method.length() == 0) {
+    return ERROR;
+  }
+  for (size_t i = 0; i < method.length(); ++i) {
+    if (!Abnf::IsTchar(method[i])) {
+      return ERROR;
+    }
+  }
+
+  this->method_ = method;
+  return OK;
+}
+
+int Request::ParseRequestTarget(std::string& request_target) {
+  // request-uri
+  return this->url_.ParseUriComponent(request_target);
+}
+
+int Request::ParseHttpVersion(std::string& http_version) {
+  /*
+          HTTP-version = HTTP-name "/" DIGIT "." DIGIT
+          HTTP-name = %s"HTTP"
+  */
+  if (http_version != "HTTP/1.1" || http_version != "HTTP/1.0") {
+    return ERROR;
+  }
+
+  this->major_version_ = 1;
+  this->minor_version_ = 1;
+  return OK;
+}
+
+int Request::ParseRequestLine(std::string& request_line) {
+  std::vector<std::string> request_line_component = Split(request_line, ' ');
+  if (request_line_component.size() != 3) {
+    return ERROR;
+  } else if (ParseMethod(request_line_component[0]) == ERROR ||
+             ParseRequestTarget(request_line_component[1]) == ERROR ||
+             ParseHttpVersion(request_line_component[2]) == ERROR) {
+    return ERROR;
+  }
+
+  return OK;
+}

--- a/src/request.hpp
+++ b/src/request.hpp
@@ -17,7 +17,7 @@ class Request {
   int major_version_;
   int minor_version_;
 
-  std::map<const std::string, std::string> headers_;
+  std::multimap<const std::string, std::string> headers_;
   std::string body_;
 
   int ParseMethod(std::string& method);

--- a/src/request.hpp
+++ b/src/request.hpp
@@ -38,6 +38,13 @@ class Request {
   Request& operator=(const Request& obj);
 
   int ReceiveRequest(char* buff, ssize_t size);
+
+  const std::string& getMethod() const;
+  const Url& getUrl() const;
+  int getMajorVersion() const;
+  int getMinorVersion() const;
+  const std::multimap<const std::string, std::string>& getHeaders() const;
+  const std::string& getBody() const;
 };
 
 #endif

--- a/src/request.hpp
+++ b/src/request.hpp
@@ -1,0 +1,39 @@
+#ifndef REQUEST_HPP
+#define REQUEST_HPP
+
+#include <iostream>
+#include <map>
+#include <vector>
+
+#include "abnf.hpp"
+#include "core.hpp"
+#include "url.hpp"
+#include "utils.hpp"
+
+class Request {
+ private:
+  std::string method_;
+  Url url_;  // todo - Url 클래스로 치환
+  int major_version_;
+  int minor_version_;
+
+  std::map<const std::string, std::string> headers_;
+  std::string body_;
+
+  int ParseMethod(std::string& method);
+  int ParseRequestTarget(std::string& request_target);
+  int ParseHttpVersion(std::string& http_version);
+  int ParseRequestLine(std::string& request_line);
+
+  int ParseHttpHeader(std::string& header) {}
+
+ public:
+  Request();
+  Request(const Request& obj);
+  ~Request();
+  Request& operator=(const Request& obj);
+
+  int ParseRequest();
+};
+
+#endif

--- a/src/request.hpp
+++ b/src/request.hpp
@@ -1,6 +1,8 @@
 #ifndef REQUEST_HPP
 #define REQUEST_HPP
 
+#include <sys/socket.h>
+
 #include <iostream>
 #include <map>
 #include <vector>
@@ -10,10 +12,12 @@
 #include "url.hpp"
 #include "utils.hpp"
 
+#define BUFFER_SIZE 4096
+
 class Request {
  private:
   std::string method_;
-  Url url_;  // todo - Url 클래스로 치환
+  Url url_;
   int major_version_;
   int minor_version_;
 
@@ -25,7 +29,7 @@ class Request {
   int ParseHttpVersion(std::string& http_version);
   int ParseRequestLine(std::string& request_line);
 
-  int ParseHttpHeader(std::string& header) {}
+  int ParseHttpHeader(std::string& header);
 
  public:
   Request();
@@ -33,7 +37,7 @@ class Request {
   ~Request();
   Request& operator=(const Request& obj);
 
-  int ParseRequest();
+  int ReceiveRequest(char* buff, ssize_t size);
 };
 
 #endif

--- a/src/request.hpp
+++ b/src/request.hpp
@@ -13,15 +13,22 @@
 #include "utils.hpp"
 
 #define BUFFER_SIZE 4096
+#define BODY_SIZE 8000  // Todo: 최대 길이 결정
 
 class Request {
  private:
+  typedef std::map<const std::string, std::string>::iterator HeadersIterator;
+
   std::string method_;
   Url url_;
   int major_version_;
   int minor_version_;
 
-  std::multimap<const std::string, std::string> headers_;
+  std::map<const std::string, std::string> headers_;
+  std::string http_host_;
+  size_t http_content_length_;
+  std::vector<std::string> http_transfer_encoding_;
+  std::string http_connection_;
   std::string body_;
 
   int ParseMethod(std::string& method);
@@ -29,7 +36,11 @@ class Request {
   int ParseHttpVersion(std::string& http_version);
   int ParseRequestLine(std::string& request_line);
 
-  int ParseHttpHeader(std::string& header);
+  int ParseCombinedFieldValue(std::string& field_name,
+                              std::string& combined_field_value);
+  int ParseFieldValue(std::string& header);
+
+  int ParseStandardHeader();
 
  public:
   Request();
@@ -39,12 +50,16 @@ class Request {
 
   int ReceiveRequest(char* buff, ssize_t size);
 
-  const std::string& getMethod() const;
-  const Url& getUrl() const;
-  int getMajorVersion() const;
-  int getMinorVersion() const;
-  const std::multimap<const std::string, std::string>& getHeaders() const;
-  const std::string& getBody() const;
+  const std::string& get_method() const;
+  const Url& get_url() const;
+  int get_major_version() const;
+  int get_minor_version() const;
+  const std::map<const std::string, std::string>& get_headers() const;
+
+  const std::vector<std::string> get_http_transfer_encoding() const;
+  int get_http_content_length() const;
+
+  const std::string& get_body() const;
 };
 
 #endif

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -278,21 +278,3 @@ int Url::ParseUriComponent(std::string& request_uri) {
 
   return OK;
 }
-
-const std::string& Url::getScheme() const { return this->scheme_; }
-
-const std::string& Url::getUser() const { return this->user_; }
-
-const std::string& Url::getPassword() const { return this->password_; }
-
-const std::string& Url::getHost() const { return this->host_; }
-
-int Url::getPort() const { return this->port_; }
-
-const std::list<Url::PathSegment>& Url::getPathSegments() const {
-  return this->path_segments_;
-}
-
-const std::map<const std::string, std::string>& Url::getQuery() const {
-  return this->query_;
-}

--- a/src/url.hpp
+++ b/src/url.hpp
@@ -42,12 +42,11 @@ class Url {
   int ParsePathSegment(std::string& path_component);
   int ParseQuery(std::string& query);
 
-  Url(const Url& obj);
-  Url& operator=(const Url& obj);
-
  public:
   Url();
   ~Url();
+  Url(const Url& obj);
+  Url& operator=(const Url& obj);
 
   int ParseUriComponent(std::string& request_uri);
 };

--- a/src/url.hpp
+++ b/src/url.hpp
@@ -12,22 +12,27 @@
 #include "abnf.hpp"
 #include "utils.hpp"
 
+#define MAX_URI_LENGTH 8000  // Todo: 최대 길이 정의
+
 class Url {
- private:
+ public:
   enum RequestTargetFrom {
     kOriginForm,
     kAbsoluteForm,
     kAuthorityForm,
     kAsteriskForm
   };
-  RequestTargetFrom request_target_form_;
-  /*
-        URI Component의 구성요소
-  */
+
   struct PathSegment {
     std::string path;
     std::map<const std::string, std::string> parameter;
   };
+
+ private:
+  RequestTargetFrom request_target_form_;
+  /*
+        URI Component의 구성요소
+  */
 
   std::string scheme_;
   std::string user_;

--- a/src/url.hpp
+++ b/src/url.hpp
@@ -54,14 +54,6 @@ class Url {
   Url& operator=(const Url& obj);
 
   int ParseUriComponent(std::string& request_uri);
-
-  const std::string& getScheme() const;
-  const std::string& getUser() const;
-  const std::string& getPassword() const;
-  const std::string& getHost() const;
-  int getPort() const;
-  const std::list<PathSegment>& getPathSegments() const;
-  const std::map<const std::string, std::string>& getQuery() const;
 };
 
 #endif

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -30,7 +30,9 @@ std::vector<std::string> Split(std::string& str, const char delimiter) {
   std::vector<std::string> buffer_container;
 
   while (getline(iss, buffer, delimiter)) {
-    buffer_container.push_back(buffer);
+    if (buffer.length() > 0) {
+      buffer_container.push_back(buffer);
+    }
   }
   return buffer_container;
 }
@@ -42,7 +44,9 @@ const std::vector<const std::string> Split(const std::string& str,
   std::vector<const std::string> buffer_container;
 
   while (getline(iss, buffer, delimiter)) {
-    buffer_container.push_back(buffer);
+    if (buffer.length() > 0) {
+      buffer_container.push_back(buffer);
+    }
   }
   return buffer_container;
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -5,7 +5,6 @@ void ToCaseInsensitve(std::string& str) {
     str[i] = std::tolower(str[i]);
   }
 }
-
 std::string Trim(const std::string s) {
   size_t front = 0;
   size_t back = s.npos;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -6,6 +6,25 @@ void ToCaseInsensitve(std::string& str) {
   }
 }
 
+std::string Trim(const std::string s) {
+  size_t front = 0;
+  size_t back = s.npos;
+
+  for (; front < s.length(); ++front) {
+    if (s[front] != 9 && s[front] != 32) {
+      break;
+    }
+  }
+
+  for (; back >= 0; --back) {
+    if (s[back] != 9 && s[back] != 32) {
+      break;
+    }
+  }
+
+  return s.substr(front, back);
+}
+
 std::vector<std::string> Split(std::string& str, const char delimiter) {
   std::istringstream iss(str);
   std::string buffer;

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -7,6 +7,8 @@
 
 void ToCaseInsensitve(std::string& str);
 
+std::string Trim(std::string s);
+
 std::vector<std::string> Split(std::string& str, const char delimiter);
 const std::vector<const std::string> Split(const std::string& str,
                                            const char delimiter);


### PR DESCRIPTION
Request 메시지의 Request Header, Request Body 파싱 알고리즘을 구현한다.

기본 기능 위주로 구현한다.
Request Header 파싱 알고리즘은 구현 완료하였으며, 추후 처리할 Standard HTTP Header 목록이 변경되면
그에 대한 파싱 알고리즘을 추가한다.

Request Body 파싱 알고리즘은 Content-Length가 주어진 경우에 대해 구현한다.
청크 인코딩 파싱 알고리즘 구현이 요구된다.
지속 커넥션에 대한 파싱 알고리즘 구현이 요구된다.

두 기능은 CGI 및 HTTP Transaction 기능 구현 이후 구현한다.

이어서 서버 정보와 Request 정보를 이용한 Target URI Reconstruct가 요구된다.