### PR TITLE
[#22] Reconstruct URI 메서드 구현

### DIFF
--- a/src/abnf.cpp
+++ b/src/abnf.cpp
@@ -50,9 +50,7 @@ bool Abnf::IsHost(std::string& s) {
         char c = s[i];
 
         switch (c) {
-          c = Abnf::DecodePctEncoded(s, i);
-          length = s.length();
-          if (c < 0) {
+          if (!Abnf::IsPctEncoded(s, i)) {
             return false;
           }
           default:
@@ -172,13 +170,10 @@ bool Abnf::IsSubDlims(char c) {
   }
 }
 
-char Abnf::DecodePctEncoded(std::string& s, const size_t pos) {
+bool Abnf::IsPctEncoded(std::string& s, const size_t pos) {
   if (pos + 2 >= s.length() || !std::isxdigit(s[pos + 1]) ||
       !std::isxdigit(s[pos + 2])) {
-    return -1;
-  } else {
-    char c = strtol(s.substr(pos + 1, pos + 3).c_str(), NULL, 16);
-    s.replace(pos, pos + 2, std::string(1, c));
-    return c;
+    return false;
   }
+  return true;
 }

--- a/src/abnf.hpp
+++ b/src/abnf.hpp
@@ -15,7 +15,7 @@ class Abnf {
   static bool IsToken(const std::string& s);
   static bool IsUnreserved(const char c);
   static bool IsSubDlims(const char c);
-  static char DecodePctEncoded(std::string& s, const size_t pos);
+  static bool IsPctEncoded(std::string& s, const size_t pos);
 };
 
 #endif

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -1,12 +1,12 @@
 #include "request.hpp"
 
-Request::Request() : url_(Url()), http_content_length_(-1) {}
+Request::Request() : uri_(Uri()), http_content_length_(-1) {}
 Request::Request(const Request& obj) { *this = obj; }
 Request::~Request() {}
 Request& Request::operator=(const Request& obj) {
   if (this != &obj) {
     this->method_ = obj.method_;
-    this->url_ = obj.url_;
+    this->uri_ = obj.uri_;
     this->major_version_ = obj.major_version_;
     this->minor_version_ = obj.minor_version_;
     this->headers_ = obj.headers_;
@@ -27,7 +27,7 @@ int Request::ParseMethod(std::string& method) {
 
 int Request::ParseRequestTarget(std::string& request_target) {
   // request-uri
-  return this->url_.ParseUriComponent(request_target);
+  return this->uri_.ParseUriComponent(request_target);
 }
 
 int Request::ParseHttpVersion(std::string& http_version) {

--- a/src/request.hpp
+++ b/src/request.hpp
@@ -10,7 +10,7 @@
 
 #include "abnf.hpp"
 #include "core.hpp"
-#include "url.hpp"
+#include "uri.hpp"
 #include "utils.hpp"
 
 #define BUFFER_SIZE 4096
@@ -23,7 +23,7 @@ class Request {
   int status_code_;
 
   std::string method_;
-  Url url_;
+  Uri uri_;
   int major_version_;
   int minor_version_;
 

--- a/src/request.hpp
+++ b/src/request.hpp
@@ -17,7 +17,7 @@
 #define BODY_SIZE 8000  // Todo: 최대 길이 결정
 
 class Request {
- private:
+ public:
   typedef std::map<const std::string, std::string>::iterator HeadersIterator;
 
   int status_code_;

--- a/src/uri.cpp
+++ b/src/uri.cpp
@@ -274,3 +274,18 @@ int Uri::ParseUriComponent(std::string& request_uri) {
 
   return OK;
 }
+
+int Uri::ReconstructTargetUri(std::string& request_host) {
+  if (this->request_target_form_ == kOriginForm) {
+    this->scheme_ = "http";
+    this->host_ = request_host;
+  }
+  typedef std::list<Uri::PathSegment>::iterator ps_iterator;
+
+  // this->request_target_ = docroot;
+  for (ps_iterator it = this->path_segments_.begin();
+       it != this->path_segments_.end(); ++it) {
+    this->request_target_ += "/" + (*it).path;
+  }
+  return OK;
+}

--- a/src/uri.cpp
+++ b/src/uri.cpp
@@ -1,16 +1,16 @@
-#include "url.hpp"
+#include "uri.hpp"
 
 // 임시
 #define OK 0
 #define ERROR 1
 
 /*
-        url.cpp에 사용되는 비멤버 함수
+        uri.cpp에 사용되는 비멤버 함수
 */
 static void InsertKeyValuePair(std::map<const std::string, std::string>& map,
                                const std::string& key, std::string value);
 
-static int ParseSubComponent(Url& url, int (Url::*Parser)(std::string& param),
+static int ParseSubComponent(Uri& uri, int (Uri::*Parser)(std::string& param),
                              std::string& uri_component, std::string delimiter);
 
 void InsertKeyValuePair(std::map<const std::string, std::string>& map,
@@ -22,7 +22,7 @@ void InsertKeyValuePair(std::map<const std::string, std::string>& map,
   }
 }
 
-int ParseSubComponent(Url& url, int (Url::*Parser)(std::string& param),
+int ParseSubComponent(Uri& uri, int (Uri::*Parser)(std::string& param),
                       std::string& uri_component, std::string delimiter) {
   size_t delimiter_pos;
   std::string sub_component;
@@ -37,19 +37,19 @@ int ParseSubComponent(Url& url, int (Url::*Parser)(std::string& param),
       sub_component = uri_component.substr(0, delimiter_pos);
       uri_component = uri_component.substr(delimiter_pos + delimiter.length());
     }
-    return (url.*Parser)(sub_component);
+    return (uri.*Parser)(sub_component);
   }
   return OK;
 }
 
 /*
-        URL 클래스 멤버 함수
+        URI 클래스 멤버 함수
 */
-Url::Url() {}
-Url::~Url() {}
+Uri::Uri() {}
+Uri::~Uri() {}
 
-Url::Url(const Url& obj) { *this = obj; }
-Url& Url::operator=(const Url& obj) {
+Uri::Uri(const Uri& obj) { *this = obj; }
+Uri& Uri::operator=(const Uri& obj) {
   if (this != &obj) {
     this->scheme_ = obj.scheme_;
     this->host_ = obj.host_;
@@ -60,7 +60,7 @@ Url& Url::operator=(const Url& obj) {
   return *this;
 }
 
-int Url::ParseScheme(std::string& scheme) {
+int Uri::ParseScheme(std::string& scheme) {
   // Section 3.1 of [URI]
 
   ToCaseInsensitve(scheme);
@@ -81,7 +81,7 @@ int Url::ParseScheme(std::string& scheme) {
   }
 }
 
-int Url::ParseAuthority(std::string& authority) {
+int Uri::ParseAuthority(std::string& authority) {
   // Section 3.2 of [URI]
   size_t delimiter_pos;
   std::string sub_component;
@@ -114,7 +114,7 @@ int Url::ParseAuthority(std::string& authority) {
   return OK;
 }
 
-int Url::ParsePathSegment(std::string& path_segment) {
+int Uri::ParsePathSegment(std::string& path_segment) {
   /*
         path-abempty = *( "/" segment )
 
@@ -134,9 +134,7 @@ int Url::ParsePathSegment(std::string& path_segment) {
 
     switch (c) {
       case '%':
-        c = Abnf::DecodePctEncoded(path_segment, i);
-        path_segment_length = path_segment.length();
-        if (c < 0) {
+        if (!Abnf::IsPctEncoded(path_segment, i)) {
           return ERROR;
         }
       case ';':
@@ -175,7 +173,7 @@ int Url::ParsePathSegment(std::string& path_segment) {
   return OK;
 }
 
-int Url::ParseQuery(std::string& query) {
+int Uri::ParseQuery(std::string& query) {
   // query = *( pchar / "/" / "?" )
   // pchar = unreserved / pct-encoded / sub-delims / ":" / "@"
 
@@ -189,9 +187,7 @@ int Url::ParseQuery(std::string& query) {
     char c = query[i];
     switch (c) {
       case '%':
-        c = Abnf::DecodePctEncoded(query, i);
-        query_length = query.length();
-        if (c < 0) {
+        if (!Abnf::IsPctEncoded(query, i)) {
           return ERROR;
         }
       case '&':
@@ -227,7 +223,7 @@ int Url::ParseQuery(std::string& query) {
   return OK;
 }
 
-int Url::ParseUriComponent(std::string& request_uri) {
+int Uri::ParseUriComponent(std::string& request_uri) {
   /*
                 absolute-form = absolute-URI
                 absolute-URI = scheme ":" hier-part [ "?" query ]
@@ -245,16 +241,16 @@ int Url::ParseUriComponent(std::string& request_uri) {
     return ERROR;
   }
 
-  if (ParseSubComponent(*this, &Url::ParseQuery, request_uri, "?") == ERROR) {
+  if (ParseSubComponent(*this, &Uri::ParseQuery, request_uri, "?") == ERROR) {
     return ERROR;
   }
 
   if (request_uri[0] != '/') {
     // absolute-form
     request_target_form_ = kAbsoluteForm;
-    if (ParseSubComponent(*this, &Url::ParseScheme, request_uri, "://") ==
+    if (ParseSubComponent(*this, &Uri::ParseScheme, request_uri, "://") ==
             ERROR ||
-        ParseSubComponent(*this, &Url::ParseAuthority, request_uri, "/") ==
+        ParseSubComponent(*this, &Uri::ParseAuthority, request_uri, "/") ==
             ERROR ||
         this->scheme_ == "" || this->host_ == "") {
       return ERROR;

--- a/src/uri.hpp
+++ b/src/uri.hpp
@@ -10,11 +10,10 @@
 #include <vector>
 
 #include "abnf.hpp"
+#include "configuration.hpp"
 #include "utils.hpp"
 
 #define MAX_URI_LENGTH 8000  // Todo: 최대 길이 정의
-
-class Request;
 
 class Uri {
  public:
@@ -25,38 +24,37 @@ class Uri {
     kAsteriskForm
   };
 
+  enum ResourceType { kFile, kDirectory, kCgiScript };
+
   struct PathSegment {
     std::string path;
     std::map<const std::string, std::string> parameter;
   };
 
+  Uri();
+  Uri(const Uri& obj);
+  ~Uri();
+  Uri& operator=(const Uri& obj);
+
+  int ParseUriComponent(std::string& request_uri);
+  int ReconstructTargetUri(std::string& request_host);
+
  private:
+  int ParseScheme(std::string& scheme);
+  int ParseAuthority(std::string& authority);
+  int ParsePathSegment(std::string& path_component);
+  int ParseQuery(std::string& query);
+
   RequestTargetFrom request_target_form_;
-  /*
-        URI Component의 구성요소
-  */
+  std::string request_target_;
 
   std::string scheme_;
   std::string user_;
   std::string password_;
   std::string host_;
   int port_;  // todo - socket API의 port 자료구조로 변경
-  std::list<PathSegment> path_segments_;  // todo - 자료구조 결정 필요
+  std::list<PathSegment> path_segments_;
   std::map<const std::string, std::string> query_;
-
-  int ParseScheme(std::string& scheme);
-  int ParseAuthority(std::string& authority);
-  int ParsePathSegment(std::string& path_component);
-  int ParseQuery(std::string& query);
-
- public:
-  Uri();
-  ~Uri();
-  Uri(const Uri& obj);
-  Uri& operator=(const Uri& obj);
-
-  int ParseUriComponent(std::string& request_uri);
-  int ReconstructTargetUri(Request& request);
 };
 
 #endif

--- a/src/uri.hpp
+++ b/src/uri.hpp
@@ -1,5 +1,5 @@
-#ifndef URL_HPP
-#define URL_HPP
+#ifndef URI_HPP
+#define URI_HPP
 
 #include <cctype>
 #include <iostream>
@@ -14,7 +14,9 @@
 
 #define MAX_URI_LENGTH 8000  // Todo: 최대 길이 정의
 
-class Url {
+class Request;
+
+class Uri {
  public:
   enum RequestTargetFrom {
     kOriginForm,
@@ -48,12 +50,13 @@ class Url {
   int ParseQuery(std::string& query);
 
  public:
-  Url();
-  ~Url();
-  Url(const Url& obj);
-  Url& operator=(const Url& obj);
+  Uri();
+  ~Uri();
+  Uri(const Uri& obj);
+  Uri& operator=(const Uri& obj);
 
   int ParseUriComponent(std::string& request_uri);
+  int ReconstructTargetUri(Request& request);
 };
 
 #endif


### PR DESCRIPTION
URL 파싱 알고리즘 결과를 이용해 정확한 리소스를 식별한다.

요청 호스트에 따라 처리할 서버를 결정한다.
처리할 리소스에 따라 위치 정보 데이터를 이용한다.

두 정보에 따라 요청 메서드를 적용하고 응답을 생성한다.