### PR TITLE
[#29] TCP 코드와 HTTP 코드 병합, index.html에 대한 요청 처리 확인

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ SRCS = $(addprefix src/, main.cpp \
 												configuration.cpp \
 												socket.cpp \
 												client.cpp \
+												abnf.cpp \
+												uri.cpp \
+												request.cpp \
+												response.cpp \
 												utils.cpp)
 OBJS = $(patsubst $(SRC_DIR)/%.cpp, $(OBJ_DIR)/%.o, $(SRCS))
 

--- a/conf/default.conf
+++ b/conf/default.conf
@@ -11,7 +11,7 @@ server {
 
 	location / {
 		allowed_method GET POST;
-		root /tmp/;
+		root /www/static;
 		auto_index off;
 		index index2.html;
 		upload_store upload/;

--- a/src/multiplexer.cpp
+++ b/src/multiplexer.cpp
@@ -123,11 +123,27 @@ void Multiplexer::HandleEvents(int nev, struct kevent events[]) {
         kevent(this->kq_, &event, 1, NULL, 0, NULL);
       } else {
         buffer[bytes_read] = 0;
-        std::string response = TEST_RESPONSE;
-
+        /*
+                기본 기능 구현 시작
+        */
+        Request request;
+        Socket sk = *(this->servers_.begin());
+        ServerConfiguration sc = sk.conf();
         std::cout << " [Request] " << std::endl;
+        ssize_t offset = 0;
+        request.ParseRequestHeader(buffer, bytes_read, offset);
+        request.uri_.ReconstructTargetUri(request.http_host_);
         std::cout << buffer << std::endl;
-        send(events[i].ident, response.c_str(), response.size(), 0);
+
+        Response response(request, sc);
+        response.HttpTransaction();
+
+        std::cout << response.response_message_ << std::endl;
+        send(events[i].ident, response.response_message_.c_str(),
+             response.response_message_.size(), 0);
+        /*
+                기본 기능 구현 끝
+        */
       }
     }
   }

--- a/src/multiplexer.hpp
+++ b/src/multiplexer.hpp
@@ -7,6 +7,8 @@
 
 #include "client.hpp"
 #include "configuration.hpp"
+#include "request.hpp"
+#include "response.hpp"
 #include "socket.hpp"
 
 class Multiplexer {

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -10,6 +10,11 @@ Request& Request::operator=(const Request& obj) {
     this->major_version_ = obj.major_version_;
     this->minor_version_ = obj.minor_version_;
     this->headers_ = obj.headers_;
+    this->http_host_ = obj.http_host_;
+    this->http_content_length_ = obj.http_content_length_;
+    this->http_transfer_encoding_ = obj.http_transfer_encoding_;
+    this->chunked_encoding_signal_ = obj.chunked_encoding_signal_;
+    this->http_connection_ = obj.http_connection_;
     this->body_ = obj.body_;
   }
   return *this;

--- a/src/request.hpp
+++ b/src/request.hpp
@@ -13,7 +13,6 @@
 #include "uri.hpp"
 #include "utils.hpp"
 
-#define BUFFER_SIZE 4096
 #define BODY_SIZE 8000  // Todo: 최대 길이 결정
 
 class Request {

--- a/src/response.hpp
+++ b/src/response.hpp
@@ -17,8 +17,7 @@ class Response {
                    const LocationConfiguration>::const_iterator LocConfIterator;
 
   enum ResourceType { kFile, kDirectory };
-
-  Response();
+  Response(Request&, ServerConfiguration&);
   Response(const Response& obj);
   ~Response();
   Response& operator=(const Response& obj);
@@ -34,10 +33,13 @@ class Response {
 
   Request request_;
   ServerConfiguration server_conf_;
+
   LocationConfiguration loc_conf_;
   std::string request_target_;
   std::string target_resource_;
   ResourceType target_resource_type_;
+
+  std::string response_message_;
 };
 
 #endif

--- a/src/uri.cpp
+++ b/src/uri.cpp
@@ -51,6 +51,8 @@ Uri::~Uri() {}
 Uri::Uri(const Uri& obj) { *this = obj; }
 Uri& Uri::operator=(const Uri& obj) {
   if (this != &obj) {
+    this->request_target_form_ = obj.request_target_form_;
+    this->request_target_ = obj.request_target_;
     this->scheme_ = obj.scheme_;
     this->host_ = obj.host_;
     this->port_ = obj.port_;

--- a/www/static/css/style.css
+++ b/www/static/css/style.css
@@ -40,13 +40,13 @@ label {
 }
 
 input[type="text"] {
-	width: 200px; /* 입력 필드의 너비를 화면 너비 - 120px로 설정 */
+	width: 200px;
 	padding: 10px;
 	margin-right: 10px;
 	margin-bottom: 10px;
 	border: 1px solid #ccc;
 	border-radius: 5px;
-	box-sizing: border-box; /* 입력 필드의 크기를 padding과 border를 포함한 크기로 설정 */
+	box-sizing: border-box;
 }
 
 input[type="submit"] {


### PR DESCRIPTION
localhost:8080/index.html 요청에 대한 정상 동작을 확인한다.

[HTTP]
웹서버에서 지원하는 기능을 추가한다.
정확한 응답 코드와 MIME 타입을 송신한다.

[TCP]
정확한 서버 설정을 로드한다.

Fixes: #29