### PR TITLE
[#40] HTTP 메서드 구현

### DIFF
--- a/src/cgi.cpp
+++ b/src/cgi.cpp
@@ -18,6 +18,14 @@ Cgi::Cgi(const Cgi& obj) { *this = obj; }
 Cgi::~Cgi() {}
 Cgi& Cgi::operator=(const Cgi& obj) {
   if (this != &obj) {
+    // this->argv_ = obj.argv_;
+    // this->envp_ = obj.envp_;
+    this->cgi2server_fd_[0] = obj.cgi2server_fd_[0];
+    this->cgi2server_fd_[1] = obj.cgi2server_fd_[1];
+    this->server2cgi_fd_[0] = obj.server2cgi_fd_[0];
+    this->server2cgi_fd_[1] = obj.server2cgi_fd_[1];
+    this->pid_ = obj.pid_;
+    this->on_ = obj.on_;
   }
   return *this;
 }
@@ -62,8 +70,8 @@ bool Cgi::IsCgiScript(const char* extension) {
   }
 }
 
-int Cgi::ExecuteCgi(const char* path, const char* extension,
-                    const char* form_data) {
+pid_t Cgi::ExecuteCgi(const char* path, const char* extension,
+                      const char* form_data) {
   std::ifstream ifs(path);
 
   if (IsCgiProgram(extension)) {
@@ -106,16 +114,7 @@ int Cgi::ExecuteCgi(const char* path, const char* extension,
     close(cgi2server_fd_[1]);
     write(server2cgi_fd_[1], form_data, std::strlen(form_data));
     close(server2cgi_fd_[1]);
-
-    char buffer[8192];
-    std::string cgi_response;
-
-    ssize_t count;
-    while ((count = read(server2cgi_fd_[0], buffer, sizeof(buffer))) > 0) {
-      cgi_response.append(buffer, count);
-    }
-    close(cgi2server_fd_[0]);
   }
 
-  return 0;
+  return HTTP_OK;
 }

--- a/src/cgi.hpp
+++ b/src/cgi.hpp
@@ -22,6 +22,8 @@ class Cgi {
  public:
   Cgi();
   ~Cgi();
+  Cgi(const Cgi& obj);
+  Cgi& operator=(const Cgi& obj);
 
   static bool IsSupportedCgi(const char*);
   int ExecuteCgi(const char*, const char*, const char*);
@@ -37,9 +39,6 @@ class Cgi {
   bool on();
 
  private:
-  Cgi(const Cgi& obj);
-  Cgi& operator=(const Cgi& obj);
-
   bool IsCgiProgram(const char*);
   bool IsCgiScript(const char*);
 

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -1,11 +1,16 @@
 #include "entity.hpp"
 
+#include "utils.hpp"
+
 Entity::Entity()
     : path_(""),
       type_(kFile),
       body_(""),
       extension_(""),
       mime_type_(""),
+      modified_s_(""),
+      modified_t_(0),
+      length_(""),
       length_n_(0) {}
 
 Entity::Entity(std::string path)
@@ -14,6 +19,9 @@ Entity::Entity(std::string path)
       body_(""),
       extension_(GetExtension(path)),
       mime_type_(),
+      modified_s_(""),
+      modified_t_(0),
+      length_(""),
       length_n_(0) {}
 
 Entity::Entity(const Entity& obj) { *this = obj; }
@@ -25,6 +33,9 @@ Entity& Entity::operator=(const Entity& obj) {
     this->body_ = obj.body_;
     this->extension_ = obj.extension_;
     this->mime_type_ = obj.mime_type_;
+    this->modified_s_ = obj.modified_s_;
+    this->modified_t_ = obj.modified_t_;
+    this->length_ = obj.length_;
     this->length_n_ = obj.length_n_;
   }
   return *this;
@@ -35,6 +46,9 @@ Entity::eType Entity::type() { return this->type_; }
 std::string Entity::body() const { return this->body_; }
 std::string Entity::extension() const { return this->extension_; }
 std::string Entity::mime_type() const { return this->mime_type_; }
+std::string Entity::modified_s() const { return this->modified_s_; }
+std::time_t Entity::modified_t() const { return this->modified_t_; }
+std::string Entity::length() const { return this->length_; }
 ssize_t Entity::length_n() { return this->length_n_; }
 
 bool Entity::IsFileExist(const char* path) {
@@ -97,10 +111,23 @@ std::string Entity::GetMimeType(std::string extension) {
   return mime_type_;
 }
 
+std::time_t Entity::GetModifiedTime(std::string path) {
+  struct stat fileInfo;
+  if (stat(path.c_str(), &fileInfo) == 0) {
+    modified_t_ = fileInfo.st_mtime;
+    modified_s_ = MakeRfc850Time(modified_t_);
+  } else {
+    modified_s_ = "";
+  }
+  return modified_t_;
+}
+
 void Entity::ReadFile() {
   mime_type_ = GetMimeType(extension_);
   body_ = GetContents(path_);
+  modified_t_ = GetModifiedTime(path_);
   length_n_ = body_.size();
+  length_ = std::to_string(length_n_);
 }
 
-void Entity::ReadBuffer() {}
+// void Entity::ReadBuffer(const char*, size_t size) {}

--- a/src/entity.hpp
+++ b/src/entity.hpp
@@ -1,8 +1,10 @@
 #ifndef ENTITY_HPP
 #define ENTITY_HPP
 
+#include <sys/stat.h>
 #include <unistd.h>
 
+#include <ctime>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -21,27 +23,34 @@ class Entity {
   static bool IsFileReadable(const char* path);
   static bool IsFileExecutable(const char* path);
 
-  eType GetType(std::string path);
-  std::string GetContents(std::string path);
-  std::string GetExtension(std::string path);
-  std::string GetMimeType(std::string extension);
-
   void ReadFile();
-  void ReadBuffer();
+  void ReadBuffer(const char*, size_t size);
 
   std::string path() const;
   eType type();
   std::string body() const;
   std::string extension() const;
   std::string mime_type() const;
+  std::string modified_s() const;
+  std::time_t modified_t() const;
+  std::string length() const;
   ssize_t length_n();
 
  private:
+  eType GetType(std::string path);
+  std::string GetContents(std::string path);
+  std::string GetExtension(std::string path);
+  std::string GetMimeType(std::string extension);
+  std::time_t GetModifiedTime(std::string path);
+
   std::string path_;
   eType type_;
   std::string body_;
   std::string extension_;
   std::string mime_type_;
+  std::string modified_s_;
+  std::time_t modified_t_;
+  std::string length_;
   ssize_t length_n_;
 };
 

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -103,10 +103,10 @@ const std::string HttpInsertHeader(std::map<HeaderKey, HeaderValue>& headers,
 int HttpHost(HeadersIn& headers_in, std::string value) {
   if (value.size() == 0 || !IsHost(value)) {
     return HTTP_BAD_REQUEST;
-  } else if (headers_in.host_ != "") {
+  } else if (headers_in.host != "") {
     return HTTP_BAD_REQUEST;
   } else {
-    headers_in.host_ = value;
+    headers_in.host = value;
     return HTTP_OK;
   }
 }
@@ -115,11 +115,11 @@ int HttpContentLength(HeadersIn& headers_in, std::string value) {
   char* end_ptr;
 
   ssize_t content_length_n = strtol(value.c_str(), &end_ptr, 10);
-  if (headers_in.content_length_ != "" || end_ptr == value || *end_ptr != 0) {
+  if (headers_in.content_length != "" || end_ptr == value || *end_ptr != 0) {
     return HTTP_BAD_REQUEST;
   } else {
-    headers_in.content_length_ = value;
-    headers_in.content_length_n_ = content_length_n;
+    headers_in.content_length = value;
+    headers_in.content_length_n = content_length_n;
     return HTTP_OK;
   }
 }
@@ -130,7 +130,7 @@ int HttpTransferEncoding(HeadersIn& headers_in, std::string value) {
   } else if (ToCaseInsensitive(Trim(value)) != "chunked") {
     return HTTP_NOT_IMPLEMENTED;
   } else {
-    headers_in.transfer_encoding_ = value;
+    headers_in.transfer_encoding = value;
     headers_in.chuncked = true;
     return HTTP_OK;
   }

--- a/src/http.hpp
+++ b/src/http.hpp
@@ -7,11 +7,6 @@
 
 #define CRLF "\r\n"
 
-#define IF_BAD_HEADER_THEN_RETURN(HeaderFunc) \
-  if (HeaderFunc == HTTP_BAD_REQUEST) {       \
-    return HTTP_BAD_REQUEST;                  \
-  }
-
 #define HTTP_GET_METHOD "GET\0"
 #define HTTP_POST_METHOD "POST\0"
 #define HTTP_DELETE_METHOD "DELETE\0"
@@ -104,44 +99,44 @@ typedef std::map<HeaderKey, HeaderValue>::const_iterator HeadersConstIterator;
 struct HeadersIn {
   std::map<HeaderKey, HeaderValue> headers_;
 
-  std::string host_;
-  std::string connection_;
-  std::string if_modified_since_;
-  std::string if_unmodified_since_;
-  std::string if_match_;
-  std::string if_none_match_;
-  std::string user_agent_;
-  std::string referer_;
-  std::string content_length_;
-  std::string content_range_;
-  std::string content_type_;
+  std::string host;
+  std::string connection;
+  std::string if_modified_since;
+  std::string if_unmodified_since;
+  std::string if_match;
+  std::string if_none_match;
+  std::string user_agent;
+  std::string referer;
+  std::string content_length;
+  std::string content_range;
+  std::string content_type;
 
-  std::string range_;
-  std::string if_range_;
+  std::string range;
+  std::string if_range;
 
-  std::string transfer_encoding_;
-  std::string te_;
-  std::string expect_;
-  std::string upgrade_;
+  std::string transfer_encoding;
+  std::string te;
+  std::string expect;
+  std::string upgrade;
 
-  ssize_t content_length_n_;
+  ssize_t content_length_n;
   bool chuncked;
 };
 
 struct HeadersOut {
-  std::string server_;
-  std::string date_;
-  std::string content_length_;
-  std::string content_encoding_;
-  std::string content_type_;
-  std::string location_;
-  std::string refresh_;
-  std::string last_modified_;
-  std::string content_range_;
-  std::string accept_ranges_;
-  std::string www_authenticate_;
-  std::string expires_;
-  std::string etag_;
+  std::string server;
+  std::string date;
+  std::string content_length;
+  std::string content_encoding;
+  std::string content_type;
+  std::string location;
+  std::string refresh;
+  std::string last_modified;
+  std::string content_range;
+  std::string accept_ranges;
+  std::string www_authenticate;
+  std::string expires;
+  std::string etag;
 };
 
 const char* HttpGetReasonPhase(int status_code);

--- a/src/transaction.hpp
+++ b/src/transaction.hpp
@@ -24,16 +24,9 @@ class Transaction {
   int ParseRequestBody(char* buff, ssize_t size, ssize_t& offset);
 
   // Response
-  int HttpGetMethod();
-  int HttpPostMethod();
-  int HttpDeleteMethod();
-
-  std::string GetTargetResource();
-  bool IsAllowedMethod();
-  bool IsRedirectedUri();
-
-  void SetCgiEnv();
-  void FreeCgiEnv();
+  int HttpProcess();
+  pid_t ExecuteCgi();
+  std::string CreateResponseMessage();
 
   /*
         Getters
@@ -47,10 +40,16 @@ class Transaction {
   int status_code();
 
  private:
-  void Test();
   int ParseRequestLine(std::string& request_line);
   int ParseFieldValue(std::string& header);
   int DecodeChunkedEncoding(char* buff, ssize_t size, ssize_t& offset);
+
+  int HttpGet();
+  int HttpPost();
+  int HttpDelete();
+
+  void SetCgiEnv();
+  void FreeCgiEnv();
 
   // Request Context
   Configuration config_;
@@ -65,6 +64,7 @@ class Transaction {
   int status_code_;
   std::string target_resource_;
   HeadersOut headers_out_;
+  std::string body_out_;
   Entity entity_;
   Cgi cgi_;
 };


### PR DESCRIPTION
GET POST DELETE 메서드를 구현한다.
구현 과정에 필요한 자료구조를 업데이트하는 함수를 구현한다.

멀티 플렉싱 과정에서 HTTP 처리 메서드를 호출하고 필요한 작업을 처리할 수 있도록
추상화환다.

Fixes: #40