### PR TITLE
[#40] HTTP 응답 메시지 생성 메서드(CreateResponseMessage) 구현

### DIFF
--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -122,12 +122,33 @@ std::time_t Entity::GetModifiedTime(std::string path) {
   return modified_t_;
 }
 
-void Entity::ReadFile() {
-  mime_type_ = GetMimeType(extension_);
-  body_ = GetContents(path_);
-  modified_t_ = GetModifiedTime(path_);
+std::string Entity::CreatePage(std::string body_line) {
+  mime_type_ = GetMimeType("html");
+  body_ =
+      "<html>\n"
+      "<head><title>" +
+      body_line +
+      "</title></head>\n"
+      "<body>\n"
+      "<center><h1>" +
+      body_line +
+      "</h1></center>\n"
+      "<hr><center>nginx/1.25.4</center>\n"
+      "</body>\n"
+      "</html>";
   length_n_ = body_.size();
   length_ = std::to_string(length_n_);
+  return body_;
+}
+// void CreateDirectoryListingPage();
+
+std::string Entity::ReadFile(const char* path) {
+  mime_type_ = GetMimeType(extension_);
+  body_ = GetContents(path);
+  modified_t_ = GetModifiedTime(path);
+  length_n_ = body_.size();
+  length_ = std::to_string(length_n_);
+  return body_;
 }
 
 // void Entity::ReadBuffer(const char*, size_t size) {}

--- a/src/entity.hpp
+++ b/src/entity.hpp
@@ -23,8 +23,10 @@ class Entity {
   static bool IsFileReadable(const char* path);
   static bool IsFileExecutable(const char* path);
 
-  void ReadFile();
-  void ReadBuffer(const char*, size_t size);
+  std::string CreatePage(std::string body_line);
+  std::string CreateDirectoryListingPage();
+  std::string ReadFile(const char* path);
+  std::string ReadBuffer(const char* buff, size_t size);
 
   std::string path() const;
   eType type();

--- a/src/http.hpp
+++ b/src/http.hpp
@@ -1,6 +1,7 @@
 #ifndef HTTP_HPP
 #define HTTP_HPP
 
+#include <ctime>
 #include <list>
 #include <map>
 #include <string>
@@ -10,6 +11,15 @@
 #define HTTP_GET_METHOD "GET\0"
 #define HTTP_POST_METHOD "POST\0"
 #define HTTP_DELETE_METHOD "DELETE\0"
+
+#define HTTP_1_1 "HTTP/1.1\0"
+#define HTTP_1_0 "HTTP/1.0\0"
+
+#define HTTP_INFORMATIONAL 1
+#define HTTP_SUCCESSFUL 2
+#define HTTP_REDIRECTION 3
+#define HTTP_CLIENT_ERROR 4
+#define HTTP_SERVER_ERROR 5
 
 #define HTTP_CONTINUE 100
 #define HTTP_SWITCHING_PROTOCOLS 101
@@ -137,6 +147,9 @@ struct HeadersOut {
   std::string www_authenticate;
   std::string expires;
   std::string etag;
+  std::string allow;
+
+  std::time_t date_t;
 };
 
 const char* HttpGetReasonPhase(int status_code);

--- a/src/transaction.hpp
+++ b/src/transaction.hpp
@@ -51,6 +51,11 @@ class Transaction {
   void SetCgiEnv();
   void FreeCgiEnv();
 
+  void SetEntityHeaders();
+  std::string AppendStatusLine();
+  std::string AppendResponseHeader(const std::string key,
+                                   const std::string value);
+
   // Request Context
   Configuration config_;
 
@@ -61,12 +66,16 @@ class Transaction {
   std::string body_in_;
 
   // Response
+  std::string http_version_;
+  std::string server_version_;
   int status_code_;
   std::string target_resource_;
   HeadersOut headers_out_;
   std::string body_out_;
   Entity entity_;
   Cgi cgi_;
+
+  std::string response_;
 };
 
 #endif


### PR DESCRIPTION
HTTP 요청 파싱, HTTP 응답 프로세싱 과정의 결과인 상태 코드에 따라
응답 메시지를 생성하는 메서드를 구현한다.

응답 메시지에 동적으로 페이지를 생성해 반환하는 경우
Entity 클래스에서 페이지를 생성해 정보를 저장하도록 한다.

Fixes: #40