### PR TITLE
[#47] error_page directive의 역할 변경

### DIFF
--- a/conf/default.conf
+++ b/conf/default.conf
@@ -3,7 +3,7 @@
 server {
 	listen 8080;
 	server_name test_server;
-	error_page 401 402 403 error_page.html;
+	error_page error_page.html;
 	client_max_body_size 1M;
 	auto_index off;
 	index index.html;
@@ -28,7 +28,7 @@ server {
 server {
 	listen 8080;
 	server_name test_server_name;
-	error_page 401 402 403 error_page.html;
+	error_page error_page.html;
 	client_max_body_size 1M;
 	auto_index off;
 	index index.html;
@@ -45,7 +45,7 @@ server {
 server {
 	listen 4242;
 	server_name test_server;
-	error_page 501 502 503 error_page.html;
+	error_page error_page.html;
 	client_max_body_size 1M;
 	auto_index on;
 	index index.html;

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -15,9 +15,8 @@ ServerConfiguration::LocationConfiguration::LocationConfiguration()
       upload_store_() {}
 
 ServerConfiguration::LocationConfiguration::LocationConfiguration(
-    const std::map<int, std::string>& error_page,
-    const std::string& client_max_body_size, const std::string& root,
-    const bool& auto_index, const std::string& index,
+    const std::string& error_page, const std::string& client_max_body_size,
+    const std::string& root, const bool& auto_index, const std::string& index,
     const std::set<std::string>& allowed_method, const std::string& return_uri,
     const std::string& upload_store)
     : error_page_(error_page),
@@ -43,10 +42,7 @@ ServerConfiguration::LocationConfiguration::operator=(
     const LocationConfiguration& ref) {
   if (this == &ref) return *this;
 
-  for (std::map<int, std::string>::const_iterator it = ref.error_page().begin();
-       it != ref.error_page().end(); it++) {
-    this->error_page_.insert(std::make_pair(it->first, it->second));
-  }
+  this->error_page_ = ref.error_page();
   this->client_max_body_size_ = ref.client_max_body_size();
   this->root_ = ref.root();
   this->auto_index_ = ref.auto_index();
@@ -63,8 +59,8 @@ ServerConfiguration::LocationConfiguration::operator=(
 
 /** ServerConfiguration::LocationConfiguration::getter **/
 
-const std::map<int, std::string>&
-ServerConfiguration::LocationConfiguration::error_page() const {
+const std::string& ServerConfiguration::LocationConfiguration::error_page()
+    const {
   return this->error_page_;
 }
 
@@ -117,9 +113,8 @@ ServerConfiguration::ServerConfiguration()
 ServerConfiguration::ServerConfiguration(
     const int& port, const std::set<std::string>& server_names,
     const std::map<std::string, LocationConfiguration>& location,
-    const std::map<int, std::string>& error_page,
-    const std::string& client_max_body_size, const std::string& root,
-    const bool& auto_index, const std::string& index)
+    const std::string& error_page, const std::string& client_max_body_size,
+    const std::string& root, const bool& auto_index, const std::string& index)
     : port_(port),
       server_names_(server_names),
       location_(location),
@@ -153,10 +148,7 @@ ServerConfiguration& ServerConfiguration::operator=(
        it != ref.location().end(); it++) {
     this->location_.insert(std::make_pair(it->first, it->second));
   }
-  for (std::map<int, std::string>::const_iterator it = ref.error_page().begin();
-       it != ref.error_page().end(); it++) {
-    this->error_page_.insert(std::make_pair(it->first, it->second));
-  }
+  this->error_page_ = ref.error_page();
   this->client_max_body_size_ = ref.client_max_body_size();
   this->root_ = ref.root();
   this->auto_index_ = ref.auto_index();
@@ -178,7 +170,7 @@ ServerConfiguration::location() const {
   return this->location_;
 }
 
-const std::map<int, std::string>& ServerConfiguration::error_page() const {
+const std::string& ServerConfiguration::error_page() const {
   return this->error_page_;
 }
 
@@ -210,13 +202,7 @@ std::ostream& operator<<(std::ostream& out,
     out << "		" << *it << std::endl;
   }
 
-  out << "	error_page: " << std::endl;
-  const std::map<int, std::string> error_page =
-      serverConfiguration.error_page();
-  for (std::map<int, std::string>::const_iterator it = error_page.begin();
-       it != error_page.end(); it++) {
-    out << "		" << it->first << " : " << it->second << std::endl;
-  }
+  out << "	error_page: " << serverConfiguration.error_page() << std::endl;
 
   out << "	client_max_body_size: "
       << serverConfiguration.client_max_body_size() << std::endl;
@@ -247,15 +233,8 @@ std::ostream& operator<<(std::ostream& out,
 std::ostream& operator<<(
     std::ostream& out,
     const ServerConfiguration::LocationConfiguration& locationConfiguration) {
-  out << "			error_page: " << std::endl;
-
-  const std::map<int, std::string> error_page =
-      locationConfiguration.error_page();
-  for (std::map<int, std::string>::const_iterator it = error_page.begin();
-       it != error_page.end(); it++) {
-    out << "				" << it->first << " : " << it->second
-        << std::endl;
-  }
+  out << "			error_page: "
+      << locationConfiguration.error_page() << std::endl;
 
   out << "			client_max_body_size: "
       << locationConfiguration.client_max_body_size() << std::endl;

--- a/src/configuration.hpp
+++ b/src/configuration.hpp
@@ -17,7 +17,7 @@ class ServerConfiguration {
    public:
     /* contructor */
     LocationConfiguration();
-    LocationConfiguration(const std::map<int, std::string>& error_page,
+    LocationConfiguration(const std::string& error_page,
                           const std::string& client_max_body_size,
                           const std::string& root, const bool& auto_index,
                           const std::string& index,
@@ -33,7 +33,7 @@ class ServerConfiguration {
     LocationConfiguration& operator=(const LocationConfiguration& ref);
 
     /* getter */
-    const std::map<int, std::string>& error_page() const;
+    const std::string& error_page() const;
     const std::string& client_max_body_size() const;
     const std::string& root() const;
     const bool& auto_index() const;
@@ -44,7 +44,7 @@ class ServerConfiguration {
 
    private:
     /* variable */
-    std::map<int, std::string> error_page_;
+    std::string error_page_;
     std::string client_max_body_size_;
     std::string root_;
     bool auto_index_;
@@ -59,9 +59,9 @@ class ServerConfiguration {
   ServerConfiguration(
       const int& port, const std::set<std::string>& server_names,
       const std::map<std::string, LocationConfiguration>& location,
-      const std::map<int, std::string>& error_page,
-      const std::string& client_max_body_size, const std::string& root,
-      const bool& auto_index, const std::string& index);
+      const std::string& error_page, const std::string& client_max_body_size,
+      const std::string& root, const bool& auto_index,
+      const std::string& index);
   ServerConfiguration(const ServerConfiguration& ref);
 
   /* destructor */
@@ -74,7 +74,7 @@ class ServerConfiguration {
   const int& port() const;
   const std::set<std::string>& server_names() const;
   const std::map<std::string, LocationConfiguration>& location() const;
-  const std::map<int, std::string>& error_page() const;
+  const std::string& error_page() const;
   const std::string& client_max_body_size() const;
   const std::string& root() const;
   const bool& auto_index() const;
@@ -85,7 +85,7 @@ class ServerConfiguration {
   int port_;
   std::set<std::string> server_names_;
   std::map<std::string, LocationConfiguration> location_;
-  std::map<int, std::string> error_page_;
+  std::string error_page_;
   std::string client_max_body_size_;
   std::string root_;
   bool auto_index_;

--- a/src/configuration_parser.cpp
+++ b/src/configuration_parser.cpp
@@ -8,7 +8,7 @@
 #define DEFAULT_SERVER_NAMES ConfigurationParser::getDefaultServerName()
 #define DEFAULT_LOCATION \
   std::map<std::string, ServerConfiguration::LocationConfiguration>()
-#define DEFAULT_ERROR_PAGE std::map<int, std::string>()
+#define DEFAULT_ERROR_PAGE ""
 #define DEFAULT_CLIENT_MAX_BODY_SIZE "1M"
 #define DEFAULT_SERVER_ROOT "/www/static"
 #define EFAULT_LOCATION_ROOT ""
@@ -157,7 +157,7 @@ int ConfigurationParser::ParseServer(const Tokens& tokens,
   std::set<std::string> server_names;
   std::map<std::string, ServerConfiguration::LocationConfiguration> location =
       DEFAULT_LOCATION;
-  std::map<int, std::string> error_page = DEFAULT_ERROR_PAGE;
+  std::string error_page = DEFAULT_ERROR_PAGE;
   std::string client_max_body_size = DEFAULT_CLIENT_MAX_BODY_SIZE;
   std::string root = DEFAULT_SERVER_ROOT;
   bool auto_index = DEFAULT_AUTO_INDEX;
@@ -271,7 +271,7 @@ int ConfigurationParser::ParseServer(const Tokens& tokens,
 int ConfigurationParser::ParseLocation(
     const Tokens& tokens, const ServerConfiguration& serverConfiguration,
     ServerConfiguration::LocationConfiguration& locationConfiguartion) {
-  std::map<int, std::string> error_page = serverConfiguration.error_page();
+  std::string error_page = serverConfiguration.error_page();
   std::string client_max_body_size = serverConfiguration.client_max_body_size();
   std::string root = EFAULT_LOCATION_ROOT;
   bool auto_index = serverConfiguration.auto_index();
@@ -326,7 +326,7 @@ int ConfigurationParser::ParseLocation(
 int ConfigurationParser::ParseServerLine(const Token& directive,
                                          const Tokens& valueTokens, int& port,
                                          std::set<std::string>& server_names,
-                                         std::map<int, std::string>& error_page,
+                                         std::string& error_page,
                                          std::string& client_max_body_size,
                                          std::string& root, bool& auto_index,
                                          std::string& index) {
@@ -354,11 +354,10 @@ int ConfigurationParser::ParseServerLine(const Token& directive,
 }
 
 int ConfigurationParser::ParseLocationLine(
-    const Token& directive, const Tokens& valueTokens,
-    std::map<int, std::string>& error_page, std::string& client_max_body_size,
-    std::string& root, bool& auto_index, std::string& index,
-    std::set<std::string>& allowed_method, std::string& return_uri,
-    std::string& upload_store) {
+    const Token& directive, const Tokens& valueTokens, std::string& error_page,
+    std::string& client_max_body_size, std::string& root, bool& auto_index,
+    std::string& index, std::set<std::string>& allowed_method,
+    std::string& return_uri, std::string& upload_store) {
   int rtn_parse = OK;
 
   if (directive == "error_page") {
@@ -404,20 +403,11 @@ int ConfigurationParser::ParseServer_names(std::set<std::string>& server_names,
   return OK;
 }
 
-int ConfigurationParser::ParseError_page(std::map<int, std::string>& error_page,
+int ConfigurationParser::ParseError_page(std::string& error_page,
                                          const Tokens& valueTokens) {
-  if (valueTokens.size() < 2) return ERROR;
+  if (valueTokens.size() != 1) return ERROR;
 
-  for (size_t idx_error_code = 0; idx_error_code < valueTokens.size() - 1;
-       idx_error_code++) {
-    if (!IsErrorCode(valueTokens[idx_error_code])) return ERROR;
-
-    int error_code;
-    std::stringstream(valueTokens[idx_error_code]) >> error_code;
-
-    error_page.insert(
-        std::make_pair(error_code, valueTokens[valueTokens.size() - 1]));
-  }
+  error_page = valueTokens[0];
 
   return OK;
 }
@@ -551,20 +541,6 @@ bool ConfigurationParser::IsPort(const std::string& port) {
   }
 
   if (port.length() > 5 || num > 65535) return false;
-
-  return true;
-}
-
-bool ConfigurationParser::IsErrorCode(const std::string& error_code) {
-  int num = 0;
-
-  for (size_t idx = 0; idx < error_code.size(); idx++) {
-    if (!std::isdigit(error_code[idx])) return false;
-
-    num = num * 10 + (error_code[idx] - '0');
-  }
-
-  if (error_code.length() > 3 || num >= 600) return false;
 
   return true;
 }

--- a/src/configuration_parser.hpp
+++ b/src/configuration_parser.hpp
@@ -40,13 +40,13 @@ class ConfigurationParser {
 
   static int ParseServerLine(const Token& directive, const Tokens& valueTokens,
                              int& port, std::set<std::string>& server_names,
-                             std::map<int, std::string>& error_page,
+                             std::string& error_page,
                              std::string& client_max_body_size,
                              std::string& root, bool& auto_index,
                              std::string& index);
   static int ParseLocationLine(
       const Token& directive, const Tokens& valueTokens,
-      std::map<int, std::string>& error_page, std::string& client_max_body_size,
+      std::string& error_page, std::string& client_max_body_size,
       std::string& root, bool& auto_index, std::string& index,
       std::set<std::string>& allowed_method, std::string& return_uri,
       std::string& upload_store);
@@ -54,7 +54,7 @@ class ConfigurationParser {
   static int ParsePort(int& port, const Tokens& valueTokens);
   static int ParseServer_names(std::set<std::string>& server_names,
                                const Tokens& valueTokens);
-  static int ParseError_page(std::map<int, std::string>& error_page,
+  static int ParseError_page(std::string& error_page,
                              const Tokens& valueTokens);
   static int ParseClient_max_body_size(std::string& client_max_body_size,
                                        const Tokens& valueTokens);
@@ -75,7 +75,6 @@ class ConfigurationParser {
   static std::set<std::string> getDefaultAllowedMethod();
 
   static bool IsPort(const std::string& port);
-  static bool IsErrorCode(const std::string& error_code);
   static bool IsAutoIndex(const std::string& auto_index);
 };
 


### PR DESCRIPTION
변경 전: `error_page` `error 상태 코드 sequence` `에러 페이지`
변경 후: `error_page` `에러 페이지`
로 문법 변경

this closes #47 