### PR TITLE
[#46] 설정파일 처리 메서드 수정

### DIFF
--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -15,10 +15,10 @@ Entity::Entity()
 
 Entity::Entity(std::string path)
     : path_(path),
-      type_(),
+      type_(GetType(path)),
       body_(""),
       extension_(GetExtension(path)),
-      mime_type_(),
+      mime_type_(GetMimeType(extension_)),
       modified_s_(""),
       modified_t_(0),
       length_(""),
@@ -123,7 +123,6 @@ std::time_t Entity::GetModifiedTime(std::string path) {
 }
 
 std::string Entity::CreatePage(std::string body_line) {
-  mime_type_ = GetMimeType("html");
   body_ =
       "<html>\n"
       "<head><title>" +
@@ -136,6 +135,7 @@ std::string Entity::CreatePage(std::string body_line) {
       "<hr><center>nginx/1.25.4</center>\n"
       "</body>\n"
       "</html>";
+  mime_type_ = GetMimeType("html");
   length_n_ = body_.size();
   length_ = std::to_string(length_n_);
   return body_;
@@ -143,7 +143,6 @@ std::string Entity::CreatePage(std::string body_line) {
 // void CreateDirectoryListingPage();
 
 std::string Entity::ReadFile(const char* path) {
-  mime_type_ = GetMimeType(extension_);
   body_ = GetContents(path);
   modified_t_ = GetModifiedTime(path);
   length_n_ = body_.size();

--- a/src/transaction.hpp
+++ b/src/transaction.hpp
@@ -33,6 +33,7 @@ class Transaction {
   */
   const Configuration& config() const;
   const Uri& uri() const;
+  Uri& uri();
   const Entity& entity() const;
   Entity& entity();
   const Cgi& cgi() const;

--- a/src/uri.cpp
+++ b/src/uri.cpp
@@ -173,7 +173,7 @@ int Uri::ParseQuery(std::string& query) {
   return HTTP_OK;
 }
 
-int Uri::ParseUriComponent(std::string& request_uri) {
+int Uri::ParseUriComponent(std::string request_uri) {
   /*
                 absolute-form = absolute-URI
                 absolute-URI = scheme ":" hier-part [ "?" query ]
@@ -217,7 +217,7 @@ int Uri::ParseUriComponent(std::string& request_uri) {
   return HTTP_OK;
 }
 
-int Uri::ReconstructTargetUri(std::string& request_host) {
+int Uri::ReconstructTargetUri(std::string request_host) {
   if (this->request_target_form_ == kOriginForm) {
     this->scheme_ = "http";
     this->host_ = request_host;

--- a/src/uri.hpp
+++ b/src/uri.hpp
@@ -19,8 +19,8 @@ class Uri {
   ~Uri();
   Uri& operator=(const Uri& obj);
 
-  int ParseUriComponent(std::string& request_uri);
-  int ReconstructTargetUri(std::string& request_host);
+  int ParseUriComponent(std::string request_uri);
+  int ReconstructTargetUri(std::string request_host);
 
   RequestTargetFrom request_target_form() const;
   const std::string& request_target() const;


### PR DESCRIPTION
### 변경 사항

ReconstructUri() 호출 코드 누락에 따른 설정파일 미적용 이슈 발생
multiplexer 단에서 ReconstructUri()를 호출할 수 있도록 getter()와 파라미터 타입을 수정한다.

설정파일 미적용으로 인한 403, 404 에러 발생 문제 해결

main force push 잘못으로 인한 재PR