### PR TITLE
[#59] 리다이렉션이 필요한 요청 처리 로직 구현

### DIFF
--- a/src/cgi.cpp
+++ b/src/cgi.cpp
@@ -1,10 +1,7 @@
 #include "cgi.hpp"
 
-#include <cstring>
-#include <fstream>
-#include <iostream>
-#include <sstream>
-#include <string>
+#define CGI_FILE ".cgi\0"
+#define PY_FILE ".py\0"
 
 Cgi::Cgi()
     : argv_(std::vector<char* const>()),
@@ -112,6 +109,7 @@ pid_t Cgi::ExecuteCgi(const char* path, const char* extension,
   } else {
     close(server2cgi_fd_[0]);
     close(cgi2server_fd_[1]);
+    // while()
     write(server2cgi_fd_[1], form_data, std::strlen(form_data));
     close(server2cgi_fd_[1]);
   }

--- a/src/cgi.hpp
+++ b/src/cgi.hpp
@@ -5,6 +5,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -12,9 +13,6 @@
 #include <vector>
 
 #include "http.hpp"
-
-#define CGI_FILE "cgi\0"
-#define PY_FILE "py\0"
 
 class Response;
 

--- a/src/configuration_parser.cpp
+++ b/src/configuration_parser.cpp
@@ -14,7 +14,7 @@
 #define DEFAULT_SERVER_ROOT "/www/static"
 #define EFAULT_LOCATION_ROOT ""
 #define DEFAULT_AUTO_INDEX false
-#define DEFAULT_INDEX "index.html"
+#define DEFAULT_INDEX ""
 #define DEFAULT_ALLOWED_METHOD ConfigurationParser::getDefaultAllowedMethod()
 #define DEFAULT_RETURN_URI ""
 #define DEFAULT_UPLOAD_STORE "/upload"

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -132,7 +132,7 @@ std::string Entity::CreatePage(std::string body_line) {
       "<center><h1>" +
       body_line +
       "</h1></center>\n"
-      "<hr><center>nginx/1.25.4</center>\n"
+      "<hr><center>webserv</center>\n"
       "</body>\n"
       "</html>";
   mime_type_ = GetMimeType("html");

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -2,6 +2,9 @@
 
 #include "utils.hpp"
 
+#define HTML_FILE ".html\0"
+#define CSS_FILE ".css\0"
+
 Entity::Entity()
     : path_(""),
       type_(kFile),
@@ -84,7 +87,7 @@ std::string Entity::GetContents(std::string path) {
 }
 
 Entity::eType Entity::GetType(std::string path) {
-  if (path.size() != 0 && *path.end() == '/') {
+  if (path.size() != 0 && path[path.size() - 1] == '/') {
     return kDirectory;
   } else {
     return kFile;
@@ -95,15 +98,15 @@ std::string Entity::GetExtension(std::string path) {
   if (delimiter_pos == path.npos) {
     extension_ = "";
   } else {
-    extension_ = path.substr(delimiter_pos + 1);
+    extension_ = path.substr(delimiter_pos);
   }
   return extension_;
 }
 
 std::string Entity::GetMimeType(std::string extension) {
-  if (extension == "html") {
+  if (extension == HTML_FILE) {
     mime_type_ = "text/html";
-  } else if (extension == "css") {
+  } else if (extension == CSS_FILE) {
     mime_type_ = "text/css";
   } else {
     mime_type_ = "text/plain";
@@ -135,12 +138,63 @@ std::string Entity::CreatePage(std::string body_line) {
       "<hr><center>webserv</center>\n"
       "</body>\n"
       "</html>";
-  mime_type_ = GetMimeType("html");
+  mime_type_ = GetMimeType(HTML_FILE);
   length_n_ = body_.size();
   length_ = std::to_string(length_n_);
   return body_;
 }
-// void CreateDirectoryListingPage();
+std::string Entity::CreateDirectoryListingPage(std::string path,
+                                               std::string request_target) {
+  std::stringstream html;
+  html << "<!DOCTYPE html>\n";
+  html << "<html>\n";
+  html << "<head><title>Index of " << request_target << "</title></head>\n";
+  html << "<body>\n";
+  html << "<h1>Index of " << request_target << "</h1><hr><pre>\n";
+
+  html << "<a href=\"../\">../</a>\n";
+
+  DIR* dir;
+  struct dirent* entry;
+  struct stat fileStat;
+
+  if ((dir = opendir(path.c_str())) != NULL) {
+    while ((entry = readdir(dir)) != NULL) {
+      std::string filename = entry->d_name;
+      if (filename != "." && filename != "..") {
+        std::string filepath = path + "/" + filename;
+        if (stat(filepath.c_str(), &fileStat) == 0) {
+          if (S_ISDIR(fileStat.st_mode)) {
+            filename += "/";
+          }
+          html << "<a href=\"" << filename << "\">" << filename << "</a>\t";
+          html << std::right << std::setw(10)
+               << std::put_time(std::localtime(&fileStat.st_mtime),
+                                "%d-%b-%Y %H:%M")
+               << "\t";
+          if (S_ISDIR(fileStat.st_mode)) {
+            html << std::setw(10) << "--\t";
+          } else {
+            html << std::setw(10) << fileStat.st_size << "\t";
+          }
+          html << "\n";
+        }
+      }
+    }
+    closedir(dir);
+  } else {
+    html << "<p>Error opening directory</p>\n";
+  }
+
+  html << "</pre><hr></body>\n";
+  html << "</html>\n";
+
+  body_ = html.str();
+  mime_type_ = GetMimeType(HTML_FILE);
+  length_n_ = body_.size();
+  length_ = std::to_string(length_n_);
+  return body_;
+}
 
 std::string Entity::ReadFile(const char* path) {
   body_ = GetContents(path);

--- a/src/entity.hpp
+++ b/src/entity.hpp
@@ -1,9 +1,11 @@
 #ifndef ENTITY_HPP
 #define ENTITY_HPP
 
+#include <dirent.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <cstring>
 #include <ctime>
 #include <fstream>
 #include <iostream>
@@ -24,7 +26,8 @@ class Entity {
   static bool IsFileExecutable(const char* path);
 
   std::string CreatePage(std::string body_line);
-  std::string CreateDirectoryListingPage();
+  std::string CreateDirectoryListingPage(std::string path,
+                                         std::string request_target);
   std::string ReadFile(const char* path);
   void ReadBuffer(const char* buff, size_t size);
 

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -286,14 +286,14 @@ int Transaction::HttpGet() {
   }
   entity_ = Entity(target_resource_);
   if (entity_.type() == Entity::kDirectory) {
-    if (config_.auto_index()) {
+    if (config_.index() != "") {
+      target_resource_ = "." + config_.root() + "/" + config_.index();
+      RETURN_STATUS_CODE HttpGet();
+    } else if (config_.auto_index()) {
       entity_.CreateDirectoryListingPage(target_resource_.c_str(),
                                          uri_.request_target().c_str());
       SetEntityHeaders();
       RETURN_STATUS_CODE HTTP_OK;
-    } else if (config_.index() != "") {
-      target_resource_ = "." + config_.root() + "/" + config_.index();
-      RETURN_STATUS_CODE HttpGet();
     } else {
       RETURN_STATUS_CODE HTTP_FORBIDDEN;
     }

--- a/src/transaction.hpp
+++ b/src/transaction.hpp
@@ -55,10 +55,12 @@ class Transaction {
   void SetCgiEnv();
   void FreeCgiEnv();
 
+  void SetAllowdMethod();
   void SetEntityHeaders();
   std::string AppendStatusLine();
   std::string AppendResponseHeader(const std::string key,
                                    const std::string value);
+  void SetErrorPage();
 
   // Request Context
   Configuration config_;


### PR DESCRIPTION
1. 에러가 발생한 경우에 대한 응답을 생성한다.
    1. 설정파일에 error_page가 존재한다면 해당 파일을 읽어 응답한다.
    2. 1번이 거짓이라면 응답 코드를 이용해 에러 페이지를 생성해 응답한다.
2. 디렉토리에 대한 요청인 경우 응답을 생성한다.
    1. 설정파일에 index가 존재한다면 해당 파일을 읽어 응답한다.
    2. 설정파일에 auto_index가 존재하면 디렉토리 리스팅 페이지를 생성해 응답한다.
    3. 1번과 2번 모두 거짓이라면 403 Forbidden 에러로 응답한다. 

