### PR TITLE
[#67] URI Percent-Encoding 디코더 기능 구현

### DIFF
--- a/conf/default.conf
+++ b/conf/default.conf
@@ -9,11 +9,14 @@ server {
 	index index.html;
 
 	location / {
-		allowed_method GET POST;
+		allowed_method GET POST DELETE;
 		root /www/static;
-		auto_index off;
-		index index.html;
+		auto_index on;
 		upload_store upload/;
+	}
+
+	location /form.html {
+		return index.html;
 	}
 
 	location /cgi-bin {

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -232,7 +232,7 @@ const Transaction::Configuration& Transaction::GetConfiguration(
     const ServerConfiguration& server_config) {
   typedef std::map<std::string, Configuration>::const_iterator
       ConfigurationIterator;
-  std::string request_target = uri_.request_target();
+  std::string request_target = uri_.decoded_request_target();
   size_t request_target_len = request_target.length();
   size_t max_common_length = 0;
 
@@ -296,7 +296,7 @@ int Transaction::HttpGet() {
       RETURN_STATUS_CODE HttpGet();
     } else if (config_.auto_index()) {
       entity_.CreateDirectoryListingPage(target_resource_.c_str(),
-                                         uri_.request_target().c_str());
+                                         uri_.decoded_request_target().c_str());
       SetEntityHeaders();
       RETURN_STATUS_CODE HTTP_OK;
     } else {
@@ -350,7 +350,7 @@ int Transaction::HttpDelete() {
   if (std::remove(this->target_resource_.c_str()) != 0) {
     RETURN_STATUS_CODE HTTP_INTERNAL_SERVER_ERROR;
   }
-  body_out_ = entity_.CreatePage("DELETED: " + uri_.request_target());
+  body_out_ = entity_.CreatePage("DELETED: " + uri_.decoded_request_target());
   RETURN_STATUS_CODE HTTP_OK;
 }
 
@@ -367,7 +367,7 @@ int Transaction::HttpProcess() {
     RETURN_STATUS_CODE HTTP_MOVED_PERMANENTLY;
   }
 
-  target_resource_ = "." + config_.root() + uri_.request_target();
+  target_resource_ = "." + config_.root() + uri_.decoded_request_target();
 
   if (config_.allowed_method().find(method_) ==
       config_.allowed_method().end()) {

--- a/src/uri.hpp
+++ b/src/uri.hpp
@@ -24,6 +24,7 @@ class Uri {
 
   RequestTargetFrom request_target_form() const;
   const std::string& request_target() const;
+  const std::string& decoded_request_target() const;
   const std::string& scheme() const;
   const std::string& user() const;
   const std::string& password() const;
@@ -36,9 +37,11 @@ class Uri {
   int ParseAuthority(std::string& authority);
   int ParsePathSegment(std::string& path_component);
   int ParseQuery(std::string& query);
+  std::string DecodeRequestTarget();
 
   RequestTargetFrom request_target_form_;
   std::string request_target_;
+  std::string decoded_request_target_;
 
   std::string scheme_;
   std::string user_;

--- a/www/static/error_page.html
+++ b/www/static/error_page.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Welcome to My Web Server</title>
+    <style>
+			body {
+				font-family: Arial, sans-serif;
+				margin: 0;
+				padding: 0;
+				background-color: #f0f0f0;
+				color: #333;
+			}
+
+			.container {
+				max-width: 800px;
+				margin: 50px auto;
+				padding: 20px;
+				background-color: #fff;
+				border-radius: 5px;
+				box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+			}
+
+			h1 {
+				text-align: center;
+				color: #ff2f00;
+			}
+
+		</style>
+</head>
+<body>
+    <div class="container">
+        <h1>ERROR</h1>
+        <p>This is a simple HTML page served by your own web server.</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
pct-encode로 표현된 %HexHex 문자열을 단일 OCTET으로 변환하는 메서드를 구현한다. 해당 메서드를 통해 Uri 클래스의 decoded_request_target_ 값을 할당한다. Transaction 클래스는 HTTP 응답 프로세스에서 request_target_대신 decoded_request_target_을 사용한다.

Fixes: #67