### PR TITLE
[#77] HTTP Connection 헤더 로직 구현

### DIFF
--- a/src/abnf.cpp
+++ b/src/abnf.cpp
@@ -82,7 +82,7 @@ bool IsObsText(unsigned char c) {
   }
 }
 
-bool IsToken(const std::string s) {
+bool IsToken(const std::string s, bool is_list) {
   // token = 1*tchar
   for (size_t i = 0; i < s.length(); ++i) {
     char c = s[i];
@@ -110,6 +110,8 @@ bool IsToken(const std::string s) {
         break;
       default:
         if (std::isalnum(c)) {
+          break;
+        } else if (is_list && (c == ',' || c == ' ')) {
           break;
         } else {
           return false;

--- a/src/abnf.hpp
+++ b/src/abnf.hpp
@@ -8,7 +8,7 @@ bool IsHost(std::string s);
 bool IsWhiteSpace(char c);
 bool IsVchar(char c);
 bool IsObsText(unsigned char c);
-bool IsToken(std::string s);
+bool IsToken(std::string s, bool is_list);
 bool IsUnreserved(char c);
 bool IsSubDlims(char c);
 bool IsPctEncoded(std::string s, size_t pos);

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -125,13 +125,28 @@ int HttpContentLength(HeadersIn& headers_in, std::string value) {
 }
 
 int HttpTransferEncoding(HeadersIn& headers_in, std::string value) {
-  if (!IsToken(value)) {
+  if (!IsToken(value, true)) {
     return HTTP_BAD_REQUEST;
   } else if (ToCaseInsensitive(Trim(value)) != "chunked") {
     return HTTP_NOT_IMPLEMENTED;
   } else {
     headers_in.transfer_encoding = value;
     headers_in.chuncked = true;
+    return HTTP_OK;
+  }
+}
+
+int HttpConnection(HeadersIn& headers_in, std::string value) {
+  if (!IsToken(value, true)) {
+    return HTTP_BAD_REQUEST;
+  } else {
+    headers_in.connection = value;
+    std::string conntection_list = RemoveWhiteSpace(headers_in.connection);
+    std::vector<std::string> connection_options = Split(conntection_list, ',');
+    if (std::find(connection_options.begin(), connection_options.end(),
+                  HTTP_CONNECTION_OPTION_CLOSE) != connection_options.end()) {
+      headers_in.connection_close = true;
+    }
     return HTTP_OK;
   }
 }

--- a/src/http.hpp
+++ b/src/http.hpp
@@ -63,6 +63,9 @@
 #define HTTP_VERSION_NOT_SUPPORTED 505
 #define HTTP_INSUFFICIENT_STORAGE 507
 
+#define HTTP_CONNECTION_OPTION_CLOSE "close\0"
+#define HTTP_CONNECTION_OPTION_KEEP_ALIVE "keep-alive\0"
+
 const static char* REASON_PHASE[] = {"Continue",
                                      "Switching Protocols",
                                      "Processing",
@@ -130,6 +133,7 @@ struct HeadersIn {
   std::string upgrade;
 
   ssize_t content_length_n;
+  bool connection_close;
   bool chuncked;
 };
 
@@ -148,8 +152,10 @@ struct HeadersOut {
   std::string expires;
   std::string etag;
   std::string allow;
+  std::string connection;
 
   std::time_t date_t;
+  bool connection_close;
 };
 
 const char* HttpGetReasonPhase(int status_code);
@@ -161,5 +167,6 @@ const std::string HttpInsertHeader(std::map<HeaderKey, HeaderValue>& headers,
 int HttpHost(HeadersIn&, const std::string);
 int HttpContentLength(HeadersIn&, const std::string);
 int HttpTransferEncoding(HeadersIn&, const std::string);
+int HttpConnection(HeadersIn&, const std::string);
 
 #endif

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -31,6 +31,17 @@ std::string ToCaseInsensitive(std::string str) {
   return insensitive_str;
 }
 
+std::string RemoveWhiteSpace(std::string str) {
+  std::string result;
+  for (size_t i = 0; i < str.length(); ++i) {
+    char c = str[i];
+    if (c != ' ') {
+      result += c;
+    }
+  }
+  return result;
+}
+
 std::string Trim(const std::string s) {
   size_t front = 0;
   size_t back = s.npos;

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -10,6 +10,7 @@
 std::string MakeRfc850Time(const std::time_t& time);
 std::string ToCaseInsensitive(std::string str);
 
+std::string RemoveWhiteSpace(std::string str);
 std::string Trim(std::string s);
 
 std::vector<std::string> Split(std::string& str, const char delimiter);


### PR DESCRIPTION
Connection 헤더를 ABNF 룰에 따라 파싱한다.
Client의 Connection 헤더 필드 값과 HTTP 상태 코드에 따라 [HTTP]에 정의된 행동대로 응답 Connection 헤더를 설정한다.
추후 응답 Connection 헤더를 이용해 실제로 TCP 통신을 제어하는 기능 구현이 요구된다.

Fixes: #77